### PR TITLE
optee_client (tee-supplicant) support for integrating optee_ftpm (TPM2) support using REE FS secure filesystem behind the /dev/tpm0 device

### DIFF
--- a/tee-supplicant/CMakeLists.txt
+++ b/tee-supplicant/CMakeLists.txt
@@ -3,7 +3,7 @@ project(tee-supplicant C)
 ################################################################################
 # Configuration flags always included
 ################################################################################
-option(RPMB_EMU "Enable tee-supplicant to emulate RPMB" ON)
+option(RPMB_EMU "Enable tee-supplicant to emulate RPMB" OFF)
 option(CFG_TA_GPROF_SUPPORT "Enable tee-supplicant support for TAs instrumented with gprof" ON)
 option(CFG_FTRACE_SUPPORT "Enable tee-supplicant support for TAs instrumented with ftrace" ON)
 option(CFG_TEE_SUPP_PLUGINS "Enable tee-supplicant plugin support" ON)
@@ -15,11 +15,11 @@ set(CFG_TEE_FS_PARENT_PATH "${CMAKE_INSTALL_LOCALSTATEDIR}/lib/tee" CACHE STRING
 # FIXME: Why do we have if defined(CFG_GP_SOCKETS) && CFG_GP_SOCKETS == 1 in the c-file?
 set(CFG_GP_SOCKETS "1" CACHE STRING "Enable GlobalPlatform Socket API support")
 set(CFG_TEE_PLUGIN_LOAD_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/plugins/" CACHE STRING "tee-supplicant's plugins path")
-
-set(CFG_TEE_GROUP "tee" CACHE STRING "Group which has access to /dev/tee* devices")
-set(CFG_TEEPRIV_GROUP "teepriv" CACHE STRING "Group which has access to /dev/teepriv* devices")
-set(CFG_TEE_SUPPL_USER "teesuppl" CACHE STRING "User account which tee-supplicant is started with")
-set(CFG_TEE_SUPPL_GROUP "teesuppl" CACHE STRING "Group account which tee-supplicant is started with")
+# PERLE changes to root
+set(CFG_TEE_GROUP "root" CACHE STRING "Group which has access to /dev/tee* devices")
+set(CFG_TEEPRIV_GROUP "root" CACHE STRING "Group which has access to /dev/teepriv* devices")
+set(CFG_TEE_SUPPL_USER "root" CACHE STRING "User account which tee-supplicant is started with")
+set(CFG_TEE_SUPPL_GROUP "root" CACHE STRING "Group account which tee-supplicant is started with")
 
 if(CFG_TEE_SUPP_PLUGINS)
 	set(CMAKE_INSTALL_RPATH "${CFG_TEE_PLUGIN_LOAD_PATH}")

--- a/tee-supplicant/optee-udev.rules.in
+++ b/tee-supplicant/optee-udev.rules.in
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
-KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", GROUP="@CFG_TEE_GROUP@", TAG+="systemd"
+KERNEL=="tee[0-9]*", MODE="0660", OWNER="@CFG_TEE_SUPPL_USER@", GROUP="@CFG_TEE_GROUP@", TAG+="systemd"
 
 # If a /dev/teepriv[0-9]* device is detected, start an instance of
 # tee-supplicant.service with the device name as parameter
-KERNEL=="teepriv[0-9]*", MODE="0660", OWNER="root", GROUP="@CFG_TEEPRIV_GROUP@", \
+KERNEL=="teepriv[0-9]*", MODE="0660", OWNER="@CFG_TEE_SUPPL_USER@", GROUP="@CFG_TEEPRIV_GROUP@", \
     TAG+="systemd", ENV{SYSTEMD_WANTS}+="tee-supplicant@%k.service"

--- a/tee-supplicant/tee-supplicant@.service.in
+++ b/tee-supplicant/tee-supplicant@.service.in
@@ -12,7 +12,7 @@ Type=forking
 User=@CFG_TEE_SUPPL_USER@
 Group=@CFG_TEE_SUPPL_GROUP@
 EnvironmentFile=-/@CMAKE_INSTALL_SYSCONFDIR@/default/tee-supplicant
-ExecStart=@CMAKE_INSTALL_USR_SBINDIR@/tee-supplicant -d /dev/%i -l /lib/firmware/optee $OPTARGS
+ExecStart=/usr/sbin/tee-supplicant -d /dev/%i -l /lib/firmware/optee $OPTARGS
 # start ftpm driver after tee-supplicant
 ExecStartPost=-/usr/sbin/rmmod tpm_ftpm_tee ; /usr/sbin/modprobe tpm_ftpm_tee
 KillSignal=SIGTERM

--- a/tee-supplicant/tee-supplicant@.service.in
+++ b/tee-supplicant/tee-supplicant@.service.in
@@ -8,10 +8,13 @@ Conflicts=shutdown.target
 Before=tpm2.target sysinit.target shutdown.target
 
 [Service]
-Type=notify
+Type=forking
 User=@CFG_TEE_SUPPL_USER@
 Group=@CFG_TEE_SUPPL_GROUP@
-EnvironmentFile=-@CMAKE_INSTALL_SYSCONFDIR@/default/tee-supplicant
-ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SBINDIR@/tee-supplicant $OPTARGS
+EnvironmentFile=-/@CMAKE_INSTALL_SYSCONFDIR@/default/tee-supplicant
+ExecStart=@CMAKE_INSTALL_USR_SBINDIR@/tee-supplicant -d /dev/%i -l /lib/firmware/optee $OPTARGS
+# start ftpm driver after tee-supplicant
+ExecStartPost=-/usr/sbin/rmmod tpm_ftpm_tee ; /usr/sbin/modprobe tpm_ftpm_tee
+KillSignal=SIGTERM
 # Workaround for fTPM TA: stop kernel module before tee-supplicant
-ExecStop=-/bin/sh -c "/sbin/modprobe -v -r tpm_ftpm_tee ; /bin/kill $MAINPID"
+ExecStop=-/usr/sbin/modprobe -v -r tpm_ftpm_tee


### PR DESCRIPTION
We need to pull in specific versions of optee_ftpm, optee_client (tee-supplicant), and ms-tpm-20-ref and fixup some compile issues. Make options were crafted for REE FS (encrypted secure filesystem in linux rootfs located under /var/lib/tee). Decided to fork copies of all the needed repos and create psl-master branches. 